### PR TITLE
portworx storage classes updated

### DIFF
--- a/aws/portworx_module/px-storageclasses.yaml
+++ b/aws/portworx_module/px-storageclasses.yaml
@@ -2,12 +2,12 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-shared-sc
+  name: portworx-shared-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "1"
- priority_io: "high"
- sharedv4: "true"
+  repl: "1"
+  priority_io: "high"
+  sharedv4: "true"
 allowVolumeExpansion: true
 volumeBindingMode: Immediate
 reclaimPolicy: Retain
@@ -15,13 +15,13 @@ reclaimPolicy: Retain
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-couchdb-sc
+  name: portworx-couchdb-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
- io_profile: "db_remote"
- disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -29,13 +29,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-elastic-sc
+  name: portworx-elastic-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
- io_profile: "db_remote"
- disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -43,13 +43,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-solr-sc
+  name: portworx-solr-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
- io_profile: "db_remote"
- disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -57,13 +57,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-cassandra-sc
+  name: portworx-cassandra-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
- io_profile: "db_remote"
- disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -71,13 +71,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-kafka-sc
+  name: portworx-kafka-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
- io_profile: "db_remote"
- disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -269,11 +269,11 @@ kind: StorageClass
 metadata:
   name: portworx-assistant
 parameters:
-   repl: "3"
-   priority_io: "high"
-   block_size: "64k"
-   io_profile: "db_remote"
-   disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  block_size: "64k"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -294,4 +294,3 @@ parameters:
   sharedv4: "false"
   io_profile: "db_remote"
   disable_io_profile_protection: "1"
-

--- a/aws/portworx_module/px-storageclasses.yaml
+++ b/aws/portworx_module/px-storageclasses.yaml
@@ -2,296 +2,295 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-shared-sc
+    name: portworx-shared-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "1"
- priority_io: "high"
- sharedv4: "true"
+    repl: "1"
+    priority_io: "high"
+    sharedv4: "true"
 allowVolumeExpansion: true
 volumeBindingMode: Immediate
 reclaimPolicy: Retain
-
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-couchdb-sc
+    name: portworx-couchdb-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
- io_profile: "db_remote"
- disable_io_profile_protection: "1"
+    repl: "3"
+    priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-elastic-sc
+    name: portworx-elastic-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
- io_profile: "db_remote"
- disable_io_profile_protection: "1"
+    repl: "3"
+    priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-solr-sc
+    name: portworx-solr-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
+    repl: "3"
+    priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-cassandra-sc
+    name: portworx-cassandra-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
+    repl: "3"
+    priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
- name: portworx-kafka-sc
+    name: portworx-kafka-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
- repl: "3"
- priority_io: "high"
+    repl: "3"
+    priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-metastoredb-sc
+    name: portworx-metastoredb-sc
 parameters:
-  priority_io: high
-  io_profile: db
-  repl: "3"
+    priority_io: high
+    repl: "3"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-shared-gp
+    name: portworx-shared-gp
 parameters:
-  priority_io: high
-  repl: "1"
-  sharedv4: "true"
+    priority_io: high
+    repl: "1"
+    sharedv4: "true"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-shared-gp2
+    name: portworx-shared-gp2
 parameters:
-  priority_io: high
-  repl: "2"
-  sharedv4: "true"
+    priority_io: high
+    repl: "2"
+    sharedv4: "true"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-shared-gp3
+    name: portworx-shared-gp3
 parameters:
-  priority_io: high
-  repl: "3"
-  sharedv4: "true"
-  io_profile: db
+    priority_io: high
+    repl: "3"
+    sharedv4: "true"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-db-gp
+    name: portworx-db-gp
 parameters:
-  io_profile: "db"
-  repl: "1"
+    repl: "1"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-db-gp3
+    name: portworx-db-gp3
 parameters:
-  io_profile: "db"
-  repl: "3"
+    repl: "3"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-nonshared-gp
+    name: portworx-nonshared-gp
 parameters:
-  priority_io: high
-  repl: "1"
+    priority_io: high
+    repl: "1"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-nonshared-gp2
+    name: portworx-nonshared-gp2
 parameters:
-  priority_io: high
-  repl: "2"
+    priority_io: high
+    repl: "2"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-gp3-sc
+    name: portworx-gp3-sc
 parameters:
-  priority_io: high
-  repl: "3"
-  io_profile: "db_remote"
+    priority_io: high
+    repl: "3"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
----
-allowVolumeExpansion: true
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: portworx-shared-gp-allow
-parameters:
-  priority_io: high
-  repl: "1"
-  sharedv4: "true"
-  io_profile: "cms"
-provisioner: kubernetes.io/portworx-volume
-reclaimPolicy: Retain
-volumeBindingMode: Immediate
-
 ---
 allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-db2-rwx-sc
+    name: portworx-shared-gp-allow
 parameters:
-  block_size: 4096b
-  repl: "3"
-  sharedv4: "true"
+    priority_io: high
+    repl: "2"
+    sharedv4: "true"
+    io_profile: "cms"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-db2-rwo-sc
+    name: portworx-db2-rwx-sc
 parameters:
-  block_size: 4096b
-  io_profile: db
-  priority_io: high
-  repl: "3"
-  sharedv4: "false"
+    block_size: 4096b
+    repl: "3"
+    sharedv4: "true"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-dv-shared-gp
+    name: portworx-db2-rwo-sc
 parameters:
-  block_size: 4096b
-  priority_io: high 
-  repl: "1"
-  shared: "true"
+    priority_io: high
+    repl: "3"
+    sharedv4: "false"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
+---
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    name: portworx-dv-shared-gp
+parameters:
+    priority_io: high 
+    repl: "1"
+    shared: "true"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-assistant
+    name: portworx-assistant
 parameters:
-   repl: "3"
-   priority_io: "high"
-   io_profile: "db"
-   block_size: "64k"
+    repl: "3"
+    priority_io: "high"
+    block_size: "64k"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: portworx-db2-fci-sc
+    name: portworx-db2-fci-sc
 provisioner: kubernetes.io/portworx-volume
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
 parameters:
-  block_size: 512b
-  io_profile: db
-  priority_io: high
-  repl: "3"
-  sharedv4: "false"
-  
+    block_size: 512b
+    priority_io: high
+    repl: "3"
+    sharedv4: "false"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"

--- a/azure/portworx_module/px-storageclasses.yaml
+++ b/azure/portworx_module/px-storageclasses.yaml
@@ -48,6 +48,8 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
     repl: "3"
     priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -60,6 +62,8 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
     repl: "3"
     priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -72,6 +76,8 @@ provisioner: kubernetes.io/portworx-volume
 parameters:
     repl: "3"
     priority_io: "high"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -82,8 +88,9 @@ metadata:
     name: portworx-metastoredb-sc
 parameters:
     priority_io: high
-    io_profile: db
     repl: "3"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -97,6 +104,8 @@ parameters:
     priority_io: high
     repl: "1"
     sharedv4: "true"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -110,6 +119,8 @@ parameters:
     priority_io: high
     repl: "2"
     sharedv4: "true"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -123,7 +134,8 @@ parameters:
     priority_io: high
     repl: "3"
     sharedv4: "true"
-    io_profile: db
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -134,8 +146,9 @@ kind: StorageClass
 metadata:
     name: portworx-db-gp
 parameters:
-    io_profile: "db"
     repl: "1"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -146,8 +159,9 @@ kind: StorageClass
 metadata:
     name: portworx-db-gp3
 parameters:
-    io_profile: "db"
     repl: "3"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -160,6 +174,8 @@ metadata:
 parameters:
     priority_io: high
     repl: "1"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -172,6 +188,8 @@ metadata:
 parameters:
     priority_io: high
     repl: "2"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -185,6 +203,7 @@ parameters:
     priority_io: high
     repl: "3"
     io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -197,7 +216,7 @@ metadata:
     name: portworx-shared-gp-allow
 parameters:
     priority_io: high
-    repl: "1"
+    repl: "2"
     sharedv4: "true"
     io_profile: "cms"
 provisioner: kubernetes.io/portworx-volume
@@ -223,11 +242,11 @@ kind: StorageClass
 metadata:
     name: portworx-db2-rwo-sc
 parameters:
-    block_size: 4096b
-    io_profile: db
     priority_io: high
     repl: "3"
     sharedv4: "false"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -238,7 +257,6 @@ kind: StorageClass
 metadata:
     name: portworx-dv-shared-gp
 parameters:
-    block_size: 4096b
     priority_io: high 
     repl: "1"
     shared: "true"
@@ -253,8 +271,9 @@ metadata:
 parameters:
     repl: "3"
     priority_io: "high"
-    io_profile: "db"
     block_size: "64k"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -270,7 +289,8 @@ reclaimPolicy: Retain
 volumeBindingMode: Immediate
 parameters:
     block_size: 512b
-    io_profile: db
     priority_io: high
     repl: "3"
     sharedv4: "false"
+    io_profile: "db_remote"
+    disable_io_profile_protection: "1"

--- a/azure/portworx_module/px-storageclasses.yaml
+++ b/azure/portworx_module/px-storageclasses.yaml
@@ -2,12 +2,12 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: portworx-shared-sc
+  name: portworx-shared-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-    repl: "1"
-    priority_io: "high"
-    sharedv4: "true"
+  repl: "1"
+  priority_io: "high"
+  sharedv4: "true"
 allowVolumeExpansion: true
 volumeBindingMode: Immediate
 reclaimPolicy: Retain
@@ -15,13 +15,13 @@ reclaimPolicy: Retain
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: portworx-couchdb-sc
+  name: portworx-couchdb-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-    repl: "3"
-    priority_io: "high"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -29,13 +29,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: portworx-elastic-sc
+  name: portworx-elastic-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-    repl: "3"
-    priority_io: "high"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -43,13 +43,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: portworx-solr-sc
+  name: portworx-solr-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-    repl: "3"
-    priority_io: "high"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -57,13 +57,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: portworx-cassandra-sc
+  name: portworx-cassandra-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-    repl: "3"
-    priority_io: "high"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -71,13 +71,13 @@ volumeBindingMode: Immediate
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-    name: portworx-kafka-sc
+  name: portworx-kafka-sc
 provisioner: kubernetes.io/portworx-volume
 parameters:
-    repl: "3"
-    priority_io: "high"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -85,27 +85,12 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-metastoredb-sc
+  name: portworx-metastoredb-sc
 parameters:
-    priority_io: high
-    repl: "3"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
-allowVolumeExpansion: true
-provisioner: kubernetes.io/portworx-volume
-reclaimPolicy: Retain
-volumeBindingMode: Immediate
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-    name: portworx-shared-gp
-parameters:
-    priority_io: high
-    repl: "1"
-    sharedv4: "true"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  priority_io: high
+  repl: "3"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -114,13 +99,13 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-shared-gp2
+  name: portworx-shared-gp
 parameters:
-    priority_io: high
-    repl: "2"
-    sharedv4: "true"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  priority_io: high
+  repl: "1"
+  sharedv4: "true"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -129,13 +114,13 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-shared-gp3
+  name: portworx-shared-gp2
 parameters:
-    priority_io: high
-    repl: "3"
-    sharedv4: "true"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  priority_io: high
+  repl: "2"
+  sharedv4: "true"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -144,11 +129,13 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-db-gp
+  name: portworx-shared-gp3
 parameters:
-    repl: "1"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  priority_io: high
+  repl: "3"
+  sharedv4: "true"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -157,11 +144,11 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-db-gp3
+  name: portworx-db-gp
 parameters:
-    repl: "3"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "1"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -170,12 +157,11 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-nonshared-gp
+  name: portworx-db-gp3
 parameters:
-    priority_io: high
-    repl: "1"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "3"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -184,12 +170,12 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-nonshared-gp2
+  name: portworx-nonshared-gp
 parameters:
-    priority_io: high
-    repl: "2"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  priority_io: high
+  repl: "1"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -198,12 +184,26 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-gp3-sc
+  name: portworx-nonshared-gp2
 parameters:
-    priority_io: high
-    repl: "3"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  priority_io: high
+  repl: "2"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
+allowVolumeExpansion: true
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: portworx-gp3-sc
+parameters:
+  priority_io: high
+  repl: "3"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -213,12 +213,12 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-shared-gp-allow
+  name: portworx-shared-gp-allow
 parameters:
-    priority_io: high
-    repl: "2"
-    sharedv4: "true"
-    io_profile: "cms"
+  priority_io: high
+  repl: "2"
+  sharedv4: "true"
+  io_profile: "cms"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -227,11 +227,11 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-db2-rwx-sc
+  name: portworx-db2-rwx-sc
 parameters:
-    block_size: 4096b
-    repl: "3"
-    sharedv4: "true"
+  block_size: 4096b
+  repl: "3"
+  sharedv4: "true"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -240,13 +240,13 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-db2-rwo-sc
+  name: portworx-db2-rwo-sc
 parameters:
-    priority_io: high
-    repl: "3"
-    sharedv4: "false"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  priority_io: high
+  repl: "3"
+  sharedv4: "false"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -255,11 +255,11 @@ allowVolumeExpansion: true
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-dv-shared-gp
+  name: portworx-dv-shared-gp
 parameters:
-    priority_io: high 
-    repl: "1"
-    shared: "true"
+  priority_io: high 
+  repl: "1"
+  shared: "true"
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -267,13 +267,13 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-assistant
+  name: portworx-assistant
 parameters:
-    repl: "3"
-    priority_io: "high"
-    block_size: "64k"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  repl: "3"
+  priority_io: "high"
+  block_size: "64k"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/portworx-volume
 reclaimPolicy: Retain
@@ -282,15 +282,15 @@ volumeBindingMode: Immediate
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: portworx-db2-fci-sc
+  name: portworx-db2-fci-sc
 provisioner: kubernetes.io/portworx-volume
 allowVolumeExpansion: true
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
 parameters:
-    block_size: 512b
-    priority_io: high
-    repl: "3"
-    sharedv4: "false"
-    io_profile: "db_remote"
-    disable_io_profile_protection: "1"
+  block_size: 512b
+  priority_io: high
+  repl: "3"
+  sharedv4: "false"
+  io_profile: "db_remote"
+  disable_io_profile_protection: "1"


### PR DESCRIPTION
Several changes were done on Portworx Storage Class specification shortly after the CP4D 3.0.1 release.
e.g.:
Portworx recommended:
- switch `io_profile` to `db_remote`
- ...

Additionally ...
Aligned the same both files:
- `aws/portworx_module/px-storageclasses.yaml`
- `azure/portworx_module/px-storageclasses.yaml`
regarding:
- indentation of 4 whitespaces is used
- removed blank lines
