### PR TITLE
Modified setup_cpd_cli.sh 

### DIFF
--- a/managed-openshift/ibmcloud/cpd_install/scripts/setup_cpd_cli.sh
+++ b/managed-openshift/ibmcloud/cpd_install/scripts/setup_cpd_cli.sh
@@ -5,7 +5,7 @@ SCRIPTS_DIR=$(pwd)
 cd $TEMPLATES_DIR
 
 rm -rf cpd-cli*
-wget --no-verbose https://github.com/IBM/cpd-cli/releases/download/v3.5.3/cpd-cli-linux-EE-3.5.3.tgz
+wget --no-verbose https://github.com/IBM/cpd-cli/releases/download/v3.5.4/cpd-cli-linux-EE-3.5.4.tgz
 mkdir -p cpd-cli
 tar -xf cpd-cli-linux-*.tgz --directory cpd-cli
 


### PR DESCRIPTION
Updated cpd_cli version to avoid the Watson Assistant install error: "Exiting due to error (This deployment version is invalid. If you used 3.5.4 newer than current 3.5.3, you should continue to use 3.5.4)."