### PR TITLE
Update to download the IBM Cloud CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,7 @@ RUN wget --no-verbose https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
  && mv kubectl /usr/bin/
 
 # ibmcloud cli (not essential)
-RUN wget --no-verbose -O ibmcloud-installer.tgz https://clis.cloud.ibm.com/download/bluemix-cli/latest/linux64 \
- && tar -xzf ibmcloud-installer.tgz \
- && Bluemix_CLI/install \
+RUN curl -fsSL https://clis.cloud.ibm.com/install/linux | sh \
  && echo 'alias ic=ibmcloud' >> $HOME/.profile
 
 # ibmcloud plugins


### PR DESCRIPTION
The bluemix-cli links are no longer supported. I thought the request here was to update the cli-releases readme with the latest links.
Due to the new architecture for the CLI back-end, there is no equivalent link to this old link. However, if you are doc'ing for users how to install the latest, this command will give the equivalent function for Linux 64:  curl -fsSL https://clis.cloud.ibm.com/install/linux | sh . You can see more info here https://cloud.ibm.com/docs/cli?topic=cli-install-ibmcloud-cli#shell_install