### PR TITLE
Removed generation in terraform provider

### DIFF
--- a/managed-openshift/ibmcloud/main.tf
+++ b/managed-openshift/ibmcloud/main.tf
@@ -17,7 +17,6 @@ locals {
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
-  generation       = 2
 }
 
 data "ibm_resource_group" "this" {


### PR DESCRIPTION
The generation field is deprecated and will be removed after couple of releases